### PR TITLE
add mixins

### DIFF
--- a/toolbar.less
+++ b/toolbar.less
@@ -1,5 +1,6 @@
 @import "_imports/colors.less";
 @import "_imports/fonts.less";
+@import "_imports/mixins.less";
 
 .htk-toolbar {
     bottom: 0;


### PR DESCRIPTION
For this file to compile in all codebases, we need to add this mixin file.

Problem:
When trying to compile toolbar.less in talentral codebase I was getting errors because it did not know what the `rounded-top-base` mixin is.

Solution:
Add mixin into toolbar.less so any codebase that uses this will have access to this mixin.